### PR TITLE
pause the read stream, not the response stream, when the buffer fills

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -103,7 +103,7 @@ class RPCStream extends Duplex {
       return
     }
 
-    if (!this.push(data)) this.pause()
+    if (!this.push(data)) this.readStream.pause()
   }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -403,3 +403,43 @@ test('register rpc twice', async (t) => {
     })
   }, 'cannot alter response stream')
 })
+
+test('a response stream survives a burst wider than its high water mark', async (t) => {
+  registerSchema()
+
+  const hrpcDir = p.join(__dirname, 'spec', 'hrpc-burst')
+  const hrpc = HRPCBuilder.from(SCHEMA_DIR, hrpcDir)
+
+  hrpc.namespace('example').register({
+    name: 'burst',
+    request: { name: 'bool', stream: false },
+    response: { name: 'uint', stream: true }
+  })
+
+  HRPCBuilder.toDisk(hrpc)
+
+  const HRPC = require(hrpcDir)
+  const rpc = new HRPC(new PassThrough())
+
+  // streamx buffers 16384 and bills every non-typed-array at 1024, so a
+  // decoded readable holds exactly 16 frames — write past that in one tick
+  const expected = []
+  for (let i = 0; i < 64; i++) expected.push(i)
+
+  rpc.onBurst((stream) => {
+    for (const i of expected) stream.write(i)
+    stream.end()
+  })
+
+  const received = []
+  const stream = rpc.burst(true)
+  stream.on('data', (data) => received.push(data))
+
+  // race a timer so a regression reports what it lost instead of hanging
+  await Promise.race([
+    new Promise((resolve) => stream.on('end', resolve)),
+    new Promise((resolve) => setTimeout(resolve, 2000))
+  ])
+
+  t.alike(received, expected, 'every frame of the burst arrives')
+})


### PR DESCRIPTION
A streaming response stops after a burst without any errors or signals and the consumer waits forever.

`RPCStream._ondata` pauses itself instead of the stream feeding it:

```js
if (!this.push(data)) this.pause()
```

`this` is the stream the caller reads from. The stream delivering frames is `this.readStream`. So this pauses the output instead of the input, with two effects:

- **Nothing resumes it.** `_read` only calls `this.readStream.resume()`, never `this.resume()`, so once this line runs the caller's stream is never resumed.
- **Nothing slows down.** The source was never paused, so frames keep arriving and the buffer keeps growing past the high water mark.

The threshold is 16 frames in one tick. streamx defaults `highWaterMark` to 16384 and counts every non-typed-array as 1024, so a decoded readable holds exactly 16 frames regardless of payload size.

Fewer than 16 in a tick is delivered normally. 16 or more delivers nothing, because `push` only queues and `'data'` is emitted later by a scheduled drain, by which point the stream is paused.

Repro, no schema or transport needed:

```js
import c from 'compact-encoding'
import { Readable } from 'streamx'
import { RPCStream } from 'hrpc/runtime'

const N = Number(process.argv[2] ?? 16)
const readStream = new Readable()
const stream = new RPCStream(readStream, c.uint, null, null)

let got = 0
stream.on('data', () => got++)
for (let i = 0; i < N; i++) readStream.push(c.encode(c.uint, i))

setImmediate(() => console.log(`sent ${N}, received ${got}`))
```

```
sent 15, received 15
sent 16, received 0
sent 100, received 0
```

This affects consumers using `.on('data')`. `for await` pulls through `_read` and is unaffected.

The producer does not have to write in bursts for this to occur. An OS pipe coalesces bytes, and bare-rpc parses every frame in a chunk in one synchronous loop, so a steady fast writer can still arrive as a single large burst on the receiving side.

The fix pauses `readStream`, matching the `_read` that already resumes it. The added test fails on main (receives 0 of 64) and passes here.

Note for CI: `basic rpc` already fails 3 asserts on main, unrelated to this change.
