### PR TITLE
treat a zero-length request payload as absent

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -57,23 +57,25 @@ module.exports = function generateCode(hrpc, { esm = false }) {
   str += '      const command = methods.get(req.command)\n'
   str += '      const responseEncoding = this._responseEncodings.get(command)\n'
   str += '      const requestEncoding = this._requestEncodings.get(command)\n'
+  // bare-rpc >= 1.3 decodes an absent payload as an empty buffer rather than
+  // null, and an empty buffer is truthy - hence the length check
   str += '      if (this._requestIsSend(command)) {\n'
   str +=
-    '        const request = req.data ? c.decode(requestEncoding, req.data) : null\n'
+    '        const request = req.data && req.data.byteLength > 0 ? c.decode(requestEncoding, req.data) : null\n'
   str += '        await this._handlers[command](request)\n'
   str += '        return\n'
   str += '      }\n'
   str +=
     '      if (!this._requestIsStream(command) && !this._responseIsStream(command)) {\n'
   str +=
-    '        const request = req.data ? c.decode(requestEncoding, req.data) : null\n'
+    '        const request = req.data && req.data.byteLength > 0 ? c.decode(requestEncoding, req.data) : null\n'
   str += '        const response = await this._handlers[command](request)\n'
   str += '        req.reply(c.encode(responseEncoding, response))\n'
   str += '      }\n'
   str +=
     '      if (!this._requestIsStream(command) && this._responseIsStream(command)) {\n'
   str +=
-    '        const request = req.data ? c.decode(requestEncoding, req.data) : null\n'
+    '        const request = req.data && req.data.byteLength > 0 ? c.decode(requestEncoding, req.data) : null\n'
   str += '        const responseStream = new RPCStream(\n'
   str += '          null,\n'
   str += '          null,\n'


### PR DESCRIPTION
`npm test` fails on main against current bare-rpc: the no-arg commands (F, G, H) assert `t.is(data, null)` and get a decoded empty value instead.

bare-rpc >= 1.3 decodes an absent payload as an empty buffer rather than null, and an empty buffer is truthy, so the generated `req.data ? decode(...) : null` takes the wrong branch. That change looks deliberate - hrpc-test's WIRE.md and its envelope fixture both assert a zero-length buffer decodes to an empty Buffer, not null - so the adjustment belongs here.

Verified green against both bare-rpc 1.3.8 and 1.2.0. It went unnoticed because package-lock.json is gitignored and main last ran CI in December, so only fresh installs see it.