### PR TITLE
add publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish
+on:
+  push:
+    tags:
+      - v*
+permissions:
+  id-token: write
+  contents: write
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+    name: Publish
+    steps:
+      - uses: holepunchto/actions/node-base@v1
+      - uses: holepunchto/actions/publish@v1

--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
     "format": "prettier --write .",
     "lint": "prettier --check ."
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/holepunchto/hrpc.git"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
hrpc publishes to npm but has no publish workflow. This is byte-identical to the one in hyperschema and hrpc-test: tag `v*` triggers `holepunchto/actions/publish@v1` in the `npm` environment.

Also adds the `repository` field, which hrpc lacks and both siblings have.

Pairs with a github-ops change moving hrpc under the bare team, which is what configures the `npm` environment and trusted publishing. Landing this first is harmless - the workflow only runs on a tag.

CI here will be red for the same pre-existing reason as #15, fixed by #16.