### PR TITLE
bump hrpc-test to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bare-path": "^3.0.0",
     "bare-stream": "^2.6.5",
     "brittle": "^3.18.0",
-    "hrpc-test": "^0.0.4",
+    "hrpc-test": "^0.1.0",
     "prettier": "^3.6.2",
     "prettier-config-holepunch": "^1.0.0"
   }


### PR DESCRIPTION
Last hand-written bump for this dep: `^0.1.0` floats across future 0.1.x releases, where `^0.0.x` pinned exactly.

5 tests / 47 asserts on node and bare.